### PR TITLE
Add untracked Github repos at 1Hive

### DIFF
--- a/config/plugins/sourcecred/github/config.json
+++ b/config/plugins/sourcecred/github/config.json
@@ -36,7 +36,9 @@
     "1Hive/uniswap-info",
     "1Hive/uniswap-v2-subgraph",
     "1Hive/uniswap-interface",
+    "1Hive/default-token-list",
     "1Hive/honeyswap-unipool-frontend",
     "1Hive/unipool",
-    "1Hive/honeycomb-subgraph"
+    "1Hive/honeycomb-subgraph",
+    "1Hive/assistant-bee"
 ]}


### PR DESCRIPTION
This commit adds [1Hive/default-token-list](https://github.com/1Hive/default-token-list) & [1Hive/assistant-bee](https://github.com/1Hive/assistant-bee) repositories on the GitHub configuration, so they can also generate cred.

