### PR TITLE
Include conviction-voting-cadcad repo

### DIFF
--- a/config/plugins/sourcecred/github/config.json
+++ b/config/plugins/sourcecred/github/config.json
@@ -40,5 +40,6 @@
     "1Hive/honeyswap-unipool-frontend",
     "1Hive/unipool",
     "1Hive/honeycomb-subgraph",
-    "1Hive/assistant-bee"
+    "1Hive/assistant-bee",
+    "1Hive/conviction-voting-cadcad"
 ]}


### PR DESCRIPTION
With @mzargham we migrated the BlockScience/Aragon_Conviction_Voting cadCAD models into [1Hive/conviction-voting-cadcad](https://github.com/1Hive/conviction-voting-cadcad). BlockScience crew is still maintaining the repo, so we request to include it into pollen so they can get some cred for it!