### PR TITLE
Fix 'set-env command is disabled' error

### DIFF
--- a/.github/workflows/generate-instance.yml
+++ b/.github/workflows/generate-instance.yml
@@ -43,7 +43,7 @@ jobs:
           cp -r ./{output,data,config,sourcecred.json} ./site/
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@3.5.7
+        uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages


### PR DESCRIPTION
Porting @hammadj's fix for the 'set-env command is disabled' error which was causing the GitHub action (i.e. updating the live site) build to fail. This is I believe what was causing the Cred scores to not update for the last few weeks. 

From their [commit](https://github.com/sourcecred/template-instance/pull/31/commits/3825857d403b112de41d8e20cf80785caee17f50):

> The error was a result of GitHub [deprecating the set-env API for actions in October 2020](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/). It was fixed by updating the `github-pages-deploy-action` to the latest version which stopped using the deprecated API.
> 
> Test Plan: Ran the updated version of the GitHub action on MetaGame's cred instance, no longer had the error

Made this fix on the Maker instance and everything went smoothly. 

Test Plan: Ran the updated version locally. Got scores that looked a bit different than the live site, though that was expected as the live site hasn't updated for a few week I believe. Below is a screenshot of Cred scores on my local instance (re-ran scores around 4:30pm PST, 11/18/2020). 

![image](https://user-images.githubusercontent.com/1634777/99607053-d7be5700-29bf-11eb-805f-bf11a4fbb2c8.png)

