### PR TITLE
Increase Node's available memory

### DIFF
--- a/.github/workflows/generate-instance.yml
+++ b/.github/workflows/generate-instance.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   GenerateCredInstance:
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: --max_old_space_size=4096
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This change should ameliorate the memory heap errors we're now seeing in 1Hive's SourceCred instance.

context here: https://nodejs.org/api/cli.html#cli_max_old_space_size_size_in_megabytes