### PR TITLE
Add `pako` dependency, required for `yarn load`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "grain": "sourcecred grain"
   },
   "devDependencies": {
+    "pako": "^2.0.3",
     "rimraf": "^3.0.2"
   }
 }


### PR DESCRIPTION
There is a dependency required by `sourcecred@0.8.1` release that we did not include. I made sure to run `yarn load` using `sourcecred@0.8.0` to make sure this dependency was truly introduced in the latest release.

After installing `pako` as a dev dependency, it worked alright. Pako seems to be a very popular dependency so it's safe to include.

https://www.npmjs.com/package/pako